### PR TITLE
Fixes mixed mode scanning with no scan args

### DIFF
--- a/src/main/java/com/fortify/plugin/jenkins/steps/CloudScanMbs.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/CloudScanMbs.java
@@ -169,8 +169,8 @@ public class CloudScanMbs extends FortifyCloudScanStep implements SimpleBuildSte
         if (StringUtils.isNotEmpty(getResolvedFilterFile(taskListener))) {
             addAllArguments(args, getResolvedFilterFile(taskListener), "-filter");
         }
+        args.add("-scan"); // must have -scan argument for mbs scans
         if (StringUtils.isNotEmpty(getResolvedScanArgs(taskListener))) {
-            args.add("-scan");
             args.add(getResolvedScanArgs(taskListener));
         }
 


### PR DESCRIPTION
- Adds the -scan argument to the cloudscan command regardless if any
scan arguments are present. The -scan is required for MBS scans.