### PR TITLE
Scancentral renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ call mvn -Djetty.port=8181 -DskipTests=true hpi:run
 
 You must obtain a Fortify SSC authentication token to use the plugin's server related functionality, which includes build failure conditions and getting all vulnerability results in Jenkins.
 
-* SSC authentication token (either JenkinsToken or CIToken). Token creation command:
+* SSC authentication token (CIToken). Token creation command:
   ```
-  $ fortifyclient token -gettoken JenkinsToken -url http://localhost:8180/ssc -user admin
+  $ fortifyclient token -gettoken CIToken -url http://localhost:8180/ssc -user admin
   ```
 * Tests. Some of the junit tests can utilize a connection to Fortify Software Security Center to verify the plugin functionality.
   To override the default SSC location (localhost:8080), you can specify the optional SSC URL parameter: 'ssc.url'.

--- a/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
+++ b/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
@@ -1142,7 +1142,8 @@ public class FortifyPlugin extends Recorder {
 			try {
 				response = client.newCall(request).execute();
 
-				if (response.isSuccessful() && response.body().string().contains("Fortify CloudScan Controller")) {
+				if (response.isSuccessful() && (response.body().string().contains("Fortify ScanCentral Controller") ||
+						response.body().string().contains("Fortify CloudScan Controller"))) {
 					return FormValidation.okWithMarkup("<font color=\"blue\">Connection successful!</font>");
 				} else {
 					return FormValidation.error("Connection failed. Check the Controller URL.");
@@ -1231,7 +1232,7 @@ public class FortifyPlugin extends Recorder {
 					if (url.trim().equalsIgnoreCase("http://") || url.trim().equalsIgnoreCase("https://")) {
 						throw new FortifyException(new Message(Message.ERROR, "URL host is required"));
 					}
-					if (!StringUtils.endsWith(url,"/cloud-ctrl")) {
+					if (!StringUtils.endsWith(url,"/scancentral-ctrl") && !StringUtils.endsWith(url,"/cloud-ctrl")) {
 						throw new FortifyException(new Message(Message.ERROR, "Invalid context"));
 					}
 				} else {

--- a/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
+++ b/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2019 Micro Focus or one of its affiliates. 
+ * (c) Copyright 2020 Micro Focus or one of its affiliates.
  * 
  * Licensed under the MIT License (the "License");
  * you may not use this file except in compliance with the License.
@@ -280,6 +280,10 @@ public class FortifyPlugin extends Recorder {
 
 	public String getUpdateServerUrl() {
 		return getUpdateContent() ? analysisRunType.getUpdateContent().getUpdateServerUrl() : "";
+	}
+
+	public String getLocaleString() {
+		return getUpdateContent() ? analysisRunType.getUpdateContent().getLocaleString() : "";
 	}
 
 	@Deprecated
@@ -715,7 +719,7 @@ public class FortifyPlugin extends Recorder {
 	private void performLocalTranslation(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
 		// Update security content
 		if (getUpdateContent()) {
-			FortifyUpdate fu = new FortifyUpdate.Builder().updateServerURL(getUpdateServerUrl()).build();
+			FortifyUpdate fu = new FortifyUpdate.Builder().updateServerURL(getUpdateServerUrl()).localeString(getLocaleString()).build();
 			fu.perform(build, launcher, listener);
 		}
 		// run Fortify SCA clean
@@ -821,16 +825,6 @@ public class FortifyPlugin extends Recorder {
 						client.init(url, token, proxyHost, proxyPort, DESCRIPTOR.getProxyUsername(),
 								DESCRIPTOR.getProxyPassword());
 					}
-					/*boolean useProxy = Jenkins.get().proxy != null;
-					if (!useProxy) {
-						client.init(url, token);
-					} else {
-						String proxyHost = Jenkins.get().proxy.name;
-						int proxyPort = Jenkins.get().proxy.port;
-						String proxyUsername = Jenkins.get().proxy.getUserName();
-						String proxyPassword = Jenkins.get().proxy.getPassword();
-						client.init(url, token, proxyHost, proxyPort, proxyUsername, proxyPassword);
-					}*/
 				}
 				return cmd.runWith(client);
 			} finally {
@@ -1714,27 +1708,21 @@ public class FortifyPlugin extends Recorder {
 			return Collections.emptyList();
 		}
 
-		public ListBoxModel doFillTranslationApplicationTypeItems() {
-			ListBoxModel options = new ListBoxModel(5);
-			options.add("Java", "java");
-			options.add(".NET", "dotnet");
-			options.add("Maven 3", "maven3");
-			options.add("Gradle", "gradle");
-			options.add("Other", "other");
-			return options;
-		}
+		public ListBoxModel doFillLocaleStringItems(String value) {
+			ListBoxModel items = new ListBoxModel();
+			items.add("English (USA)", "en_US");
+			items.add("Spanish", "es");
+			items.add("Japanese", "ja");
+			items.add("Korean", "ko");
+			items.add("Portuguese (Brazil)", "pt_BR");
+			items.add("Chinese (China)", "zh_CN");
+			items.add("Chinese (Taiwan)", "zh_TW");
 
-		public ListBoxModel doFillTranslationJavaVersionItems() {
-			ListBoxModel options = new ListBoxModel();
-			options.add("1.5", "1.5");
-			options.add("1.6", "1.6");
-			options.add("1.7", "1.7");
-			options.add("1.8", "1.8");
-			options.add("1.9", "1.9");
-			options.add("10", "10");
-			options.add("11", "11");
-			options.add("12", "12");
-			return options;
+			if ((null == value) || (0 == value.length())) {
+				items.get(0).selected = true; // default to en_US
+			}
+
+			return items;
 		}
 	}
 
@@ -2397,6 +2385,7 @@ public class FortifyPlugin extends Recorder {
 
 	public static class UpdateContentBlock {
 		private String updateServerUrl;
+		private String localeString;
 		private UseProxyBlock useProxy;
 
 		@DataBoundConstructor
@@ -2413,6 +2402,10 @@ public class FortifyPlugin extends Recorder {
 		}
 		@DataBoundSetter
 		public void setUpdateServerUrl(String updateServerUrl) { this.updateServerUrl = updateServerUrl; }
+
+		public String getLocaleString() { return localeString; }
+		@DataBoundSetter
+		public void setLocaleString(String localeString) { this.localeString = localeString; }
 
 		@Deprecated
 		public boolean getUpdateUseProxy() {

--- a/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
+++ b/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
@@ -282,8 +282,8 @@ public class FortifyPlugin extends Recorder {
 		return getUpdateContent() ? analysisRunType.getUpdateContent().getUpdateServerUrl() : "";
 	}
 
-	public String getLocaleString() {
-		return getUpdateContent() ? analysisRunType.getUpdateContent().getLocaleString() : "";
+	public String getLocale() {
+		return getUpdateContent() ? analysisRunType.getUpdateContent().getLocale() : "";
 	}
 
 	@Deprecated
@@ -719,7 +719,7 @@ public class FortifyPlugin extends Recorder {
 	private void performLocalTranslation(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
 		// Update security content
 		if (getUpdateContent()) {
-			FortifyUpdate fu = new FortifyUpdate.Builder().updateServerURL(getUpdateServerUrl()).localeString(getLocaleString()).build();
+			FortifyUpdate fu = new FortifyUpdate.Builder().updateServerURL(getUpdateServerUrl()).locale(getLocale()).build();
 			fu.perform(build, launcher, listener);
 		}
 		// run Fortify SCA clean
@@ -1708,15 +1708,15 @@ public class FortifyPlugin extends Recorder {
 			return Collections.emptyList();
 		}
 
-		public ListBoxModel doFillLocaleStringItems(String value) {
+		public ListBoxModel doFillLocaleItems(String value) {
 			ListBoxModel items = new ListBoxModel();
-			items.add("English (USA)", "en_US");
-			items.add("Spanish", "es");
+			items.add("English", "en");
+			items.add("Chinese Simplified", "zh_CN");
+			items.add("Chinese Traditional", "zh_TW");
 			items.add("Japanese", "ja");
 			items.add("Korean", "ko");
 			items.add("Portuguese (Brazil)", "pt_BR");
-			items.add("Chinese (China)", "zh_CN");
-			items.add("Chinese (Taiwan)", "zh_TW");
+			items.add("Spanish", "es");
 
 			if ((null == value) || (0 == value.length())) {
 				items.get(0).selected = true; // default to en_US
@@ -2385,7 +2385,7 @@ public class FortifyPlugin extends Recorder {
 
 	public static class UpdateContentBlock {
 		private String updateServerUrl;
-		private String localeString;
+		private String locale;
 		private UseProxyBlock useProxy;
 
 		@DataBoundConstructor
@@ -2403,9 +2403,9 @@ public class FortifyPlugin extends Recorder {
 		@DataBoundSetter
 		public void setUpdateServerUrl(String updateServerUrl) { this.updateServerUrl = updateServerUrl; }
 
-		public String getLocaleString() { return localeString; }
+		public String getLocale() { return locale; }
 		@DataBoundSetter
-		public void setLocaleString(String localeString) { this.localeString = localeString; }
+		public void setLocale(String locale) { this.locale = locale; }
 
 		@Deprecated
 		public boolean getUpdateUseProxy() {

--- a/src/main/java/com/fortify/plugin/jenkins/steps/CloudScanArguments.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/CloudScanArguments.java
@@ -48,13 +48,8 @@ public class CloudScanArguments extends FortifyCloudScanStep implements SimpleBu
         setLastBuild(run);
         PrintStream log = taskListener.getLogger();
         log.println("Fortify Jenkins plugin v " + VERSION);
-        log.println("Launching Fortify cloudscan arguments command");
-        //String projectRoot = filePath.getRemote() + File.separator + ".fortify";
-        String cloudscanExec = null;
-
-        if (cloudscanExec == null) {
-            cloudscanExec = getCloudScanExecutable(run, filePath, launcher, taskListener);
-        }
+        log.println("Launching Fortify scancentral arguments command");
+        String cloudscanExec = getScancentralExecutable(run, filePath, launcher, taskListener);
 
         EnvVars vars = run.getEnvironment(taskListener);
         ArrayList<String> args = new ArrayList<String>(2);

--- a/src/main/java/com/fortify/plugin/jenkins/steps/CloudScanMbs.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/CloudScanMbs.java
@@ -116,11 +116,7 @@ public class CloudScanMbs extends FortifyCloudScanStep implements SimpleBuildSte
         log.println("Fortify Jenkins plugin v " + VERSION);
         log.println("Performing Fortify remote scan");
         String projectRoot = filePath.getRemote() + File.separator + ".fortify";
-        String cloudscanExec = null;
-
-        if (cloudscanExec == null) {
-            cloudscanExec = getCloudScanExecutable(run, filePath, launcher, taskListener);
-        }
+        String cloudscanExec = getScancentralExecutable(run, filePath, launcher, taskListener);
 
         EnvVars vars = run.getEnvironment(taskListener);
         ArrayList<String> args = new ArrayList<String>(2);

--- a/src/main/java/com/fortify/plugin/jenkins/steps/CloudScanStart.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/CloudScanStart.java
@@ -29,8 +29,6 @@ public class CloudScanStart extends FortifyCloudScanStep implements SimpleBuildS
     private FortifyPlugin.RemoteOptionalConfigBlock remoteOptionalConfig;
     private FortifyPlugin.UploadSSCBlock uploadSSC;
 
-    //private String mbsFile;
-    //private boolean createMbs;
     private String buildID;
 
     @DataBoundConstructor
@@ -87,22 +85,6 @@ public class CloudScanStart extends FortifyCloudScanStep implements SimpleBuildS
         }
     }
 
-    /*public String getMbsFile() {
-        return mbsFile;
-    }
-
-    public void setMbsFile(String mbsFile) {
-        this.mbsFile = mbsFile;
-    }
-
-    public boolean isCreateMbs() {
-        return createMbs;
-    }
-
-    public void setCreateMbs(boolean createMbs) {
-        this.createMbs = createMbs;
-    }*/
-
     public String getSensorPoolName() {
         return getRemoteOptionalConfig() == null ? "" : getRemoteOptionalConfig().getSensorPoolUUID();
     }
@@ -118,10 +100,6 @@ public class CloudScanStart extends FortifyCloudScanStep implements SimpleBuildS
     public String getFilterFile() {
         return getRemoteOptionalConfig() == null ? "" : getRemoteOptionalConfig().getFilterFile();
     }
-
-    /*public String getResultsFile() {
-        return getRemoteOptionalConfig() == null ? "" : getRemoteOptionalConfig().getResultsFile();
-    }*/
 
     public String getApplicationName() {
         return getUploadSSC() == null ? "" : getUploadSSC().getAppName();
@@ -160,10 +138,6 @@ public class CloudScanStart extends FortifyCloudScanStep implements SimpleBuildS
         return resolve(getBuildFile(), listener);
     }
 
-    /*public String getResolvedMbsFile(TaskListener listener) {
-        return resolve(getMbsFile(), listener);
-    }*/
-
     public String getResolvedSensorPoolName(TaskListener listener) {
         return resolve(getSensorPoolName(), listener);
     }
@@ -182,8 +156,6 @@ public class CloudScanStart extends FortifyCloudScanStep implements SimpleBuildS
 
     public String getResolvedBuildID(TaskListener listener) { return resolve(getBuildID(), listener); }
 
-    /*public String getResolvedScanArgs(TaskListener listener) { return resolve(getScanOptions(), listener); }*/
-
     public String getResolvedApplicationName(TaskListener listener) { return resolve(getApplicationName(), listener); }
 
     public String getResolvedApplicationVersion(TaskListener listener) { return resolve(getApplicationVersion(), listener); }
@@ -195,8 +167,6 @@ public class CloudScanStart extends FortifyCloudScanStep implements SimpleBuildS
     public String getResolvedPythonVirtualEnv(TaskListener listener) { return resolve(getPythonVirtualEnv(), listener); }
 
     public String getResolvedPhpVersion(TaskListener listener) { return resolve(getPhpVersion(), listener); }
-
-    /*public String getResolvedResultsFile(TaskListener listener) { return resolve(getResultsFile(), listener); }*/
 
     @Override
     public StepExecution start(StepContext context) throws Exception {
@@ -210,11 +180,7 @@ public class CloudScanStart extends FortifyCloudScanStep implements SimpleBuildS
         log.println("Fortify Jenkins plugin v " + VERSION);
         log.println("Performing Fortify remote analysis");
         String projectRoot = filePath.getRemote() + File.separator + ".fortify";
-        String cloudscanExec = null;
-
-        if (cloudscanExec == null) {
-            cloudscanExec = getCloudScanExecutable(run, filePath, launcher, taskListener);
-        }
+        String cloudscanExec = getScancentralExecutable(run, filePath, launcher, taskListener);
 
         EnvVars vars = run.getEnvironment(taskListener);
         ArrayList<String> args = new ArrayList<String>(2);
@@ -270,11 +236,6 @@ public class CloudScanStart extends FortifyCloudScanStep implements SimpleBuildS
             args.add("-project-root");
             args.add(projectRoot);
         }
-        /*if (StringUtils.isNotEmpty(getResolvedResultsFile(taskListener))) {
-            args.add("-o"); // overwrite existing FPR
-            args.add("-f");
-            args.add(getResolvedResultsFile(taskListener));
-        }*/
         if (StringUtils.isNotEmpty(getResolvedEmailAddr(taskListener))) {
             args.add("-email");
             args.add(getResolvedEmailAddr(taskListener));

--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifyCloudScanStep.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifyCloudScanStep.java
@@ -30,4 +30,17 @@ public abstract class FortifyCloudScanStep extends FortifyStep {
                 listener);
     }
 
+    /* Look for scancentral executable in Jenkins environment, if not found, get the old cloudscan executable. It's considered not found
+     * if the getExecutable() returns just the filename rather than the full path.*/
+    protected String getScancentralExecutable(Run<?, ?> build, FilePath workspace, Launcher launcher,
+                                            TaskListener listener) throws InterruptedException, IOException {
+        String filename = "scancentral" + (launcher.isUnix() ? "" : ".bat");
+        String exec = getExecutable(filename, true, build, workspace, launcher,
+                listener);
+        if (exec.equals(filename)) {
+            return getCloudScanExecutable(build, workspace, launcher, listener);
+        } else {
+            return exec;
+        }
+    }
 }

--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifyCloudScanStep.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifyCloudScanStep.java
@@ -27,7 +27,7 @@ public abstract class FortifyCloudScanStep extends FortifyStep {
     protected String getCloudScanExecutable(Run<?, ?> build, FilePath workspace, Launcher launcher,
                                          TaskListener listener) throws InterruptedException, IOException {
         return getExecutable("cloudscan" + (launcher.isUnix() ? "" : ".bat"), true, build, workspace, launcher,
-                listener);
+                listener, null);
     }
 
     /* Look for scancentral executable in Jenkins environment, if not found, get the old cloudscan executable. It's considered not found
@@ -35,8 +35,9 @@ public abstract class FortifyCloudScanStep extends FortifyStep {
     protected String getScancentralExecutable(Run<?, ?> build, FilePath workspace, Launcher launcher,
                                             TaskListener listener) throws InterruptedException, IOException {
         String filename = "scancentral" + (launcher.isUnix() ? "" : ".bat");
+        String msg = "Checking for cloudscan executable";
         String exec = getExecutable(filename, true, build, workspace, launcher,
-                listener);
+                listener, msg);
         if (exec.equals(filename)) {
             return getCloudScanExecutable(build, workspace, launcher, listener);
         } else {

--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifySCAStep.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifySCAStep.java
@@ -86,30 +86,32 @@ public abstract class FortifySCAStep extends FortifyStep {
 
 	protected String getSourceAnalyzerExecutable(Run<?, ?> build, FilePath workspace, Launcher launcher,
 			TaskListener listener) throws InterruptedException, IOException {
-		return getExecutable("sourceanalyzer" + (launcher.isUnix() ? "" : ".exe"), true, build, workspace, launcher,
-				listener);
+		return getExecutable("sourceanalyzer" + (launcher.isUnix() ? "" : ".exe"), true, build, workspace,
+				launcher, listener, null);
 	}
 
 	protected String getMavenExecutable(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener)
 			throws InterruptedException, IOException {
-		return getExecutable("mvn" + (launcher.isUnix() ? "" : ".cmd"), false, build, workspace, launcher, listener);
+		return getExecutable("mvn" + (launcher.isUnix() ? "" : ".cmd"), false, build, workspace, launcher,
+				listener, null);
 	}
 
 	protected String getGradleExecutable(boolean useWrapper, Run<?, ?> build, FilePath workspace, Launcher launcher,
 			TaskListener listener) throws InterruptedException, IOException {
 		return getExecutable("gradle" + (useWrapper ? "w" : "") + (launcher.isUnix() ? "" : ".bat"), false, build,
-				workspace, launcher, listener);
+				workspace, launcher, listener, null);
 	}
 
 	protected String getDevenvExecutable(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener)
 			throws InterruptedException, IOException {
-		return getExecutable("devenv" + (launcher.isUnix() ? "" : ".exe"), false, build, workspace, launcher, listener);
+		return getExecutable("devenv" + (launcher.isUnix() ? "" : ".exe"), false, build, workspace, launcher,
+				listener, null);
 	}
 
 	protected String getMSBuildExecutable(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener)
 			throws InterruptedException, IOException {
 		return getExecutable("msbuild" + (launcher.isUnix() ? "" : ".exe"), false, build, workspace, launcher,
-				listener);
+				listener, null);
 	}
 
 	public Integer getResolvedMaxHeap(TaskListener listener) {

--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
@@ -61,12 +61,13 @@ public abstract class FortifyStep extends Step implements SimpleBuildStep {
 	 * @param workspace
 	 * @param launcher
 	 * @param listener
+	 * @param msg
 	 * @return found executable or filename if not found
 	 * @throws InterruptedException
 	 * @throws IOException
 	 */
 	protected String getExecutable(String filename, boolean checkFortifyHome, Run<?, ?> build, FilePath workspace,
-			Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
+			Launcher launcher, TaskListener listener, String msg) throws InterruptedException, IOException {
 		EnvVars env = build.getEnvironment(listener);
 		String fortifyHome = null;
 		String path = null;
@@ -82,13 +83,15 @@ public abstract class FortifyStep extends Step implements SimpleBuildStep {
 		}
 		String s = workspace.act(new FindExecutableRemoteService(filename, fortifyHome, path, workspace));
 		if (s == null) {
-			listener.getLogger().printf("executable not found: %s%n", filename);
-			listener.getLogger().printf("\tfortify_home: %s%n", fortifyHome);
-			listener.getLogger().printf("\tpath: %s%n", path);
-			listener.getLogger().printf("\tworkspace: %s%n", workspace.getRemote());
+			listener.getLogger().printf("WARNING: %s executable not found in the Jenkins environment.%n", filename);
+			if (msg != null) {
+				listener.getLogger().println(msg);
+			} else {
+				listener.getLogger().printf("Checking system PATH for %s.%n", filename);
+			}
 			return filename;
 		} else {
-			listener.getLogger().printf("found executable: %s%n", s);
+			listener.getLogger().printf("Found executable: %s%n", s);
 			return s;
 		}
 	}

--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifyUpdate.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifyUpdate.java
@@ -46,16 +46,16 @@ import hudson.model.TaskListener;
 
 public class FortifyUpdate extends FortifyStep {
 	private String updateServerURL;
-	private String localeString;
+	private String locale;
 	private transient String proxyURL;
 	private transient String proxyUsername;
 	private transient String proxyPassword;
 	private transient boolean useProxy;
 
 	@DataBoundConstructor
-	public FortifyUpdate(String updateServerURL, String localeString) {
+	public FortifyUpdate(String updateServerURL, String locale) {
 		this.updateServerURL = updateServerURL;
-		this.localeString = localeString;
+		this.locale = locale;
 	}
 
 	@Deprecated
@@ -72,7 +72,7 @@ public class FortifyUpdate extends FortifyStep {
 		return updateServerURL;
 	}
 
-	public String getLocaleString() { return localeString; }
+	public String getLocale() { return locale; }
 
 	@Deprecated
 	public String getProxyURL() {
@@ -100,7 +100,7 @@ public class FortifyUpdate extends FortifyStep {
 	}
 
 	@DataBoundSetter
-	public void setLocaleString(String localeString) { this.localeString = localeString; }
+	public void setLocale(String locale) { this.locale = locale; }
 
 	@DataBoundSetter @Deprecated
 	public void setProxyURL(String proxyURL) {
@@ -126,8 +126,8 @@ public class FortifyUpdate extends FortifyStep {
 		return resolve(getUpdateServerURL(), listener);
 	}
 
-	public String getResolvedLocaleString(TaskListener listener) {
-		return resolve(getLocaleString(), listener);
+	public String getResolvedLocale(TaskListener listener) {
+		return resolve(getLocale(), listener);
 	}
 
 	@Deprecated
@@ -173,7 +173,7 @@ public class FortifyUpdate extends FortifyStep {
 			}
 		}
 
-		String localeStr = getResolvedLocaleString(listener);
+		String localeStr = getResolvedLocale(listener);
 		if (!"".equals(localeStr)) {
 			args.add("-locale");
 			args.add(localeStr);
@@ -220,15 +220,15 @@ public class FortifyUpdate extends FortifyStep {
 			return ImmutableSet.of(Run.class, FilePath.class, Launcher.class, TaskListener.class);
 		}
 
-		public ListBoxModel doFillLocaleStringItems(String value) {
+		public ListBoxModel doFillLocaleItems(String value) {
 			ListBoxModel items = new ListBoxModel();
-			items.add("English (USA)", "en_US");
-			items.add("Spanish", "es");
+			items.add("English", "en");
+			items.add("Chinese Simplified", "zh_CN");
+			items.add("Chinese Traditional", "zh_TW");
 			items.add("Japanese", "ja");
 			items.add("Korean", "ko");
 			items.add("Portuguese (Brazil)", "pt_BR");
-			items.add("Chinese (China)", "zh_CN");
-			items.add("Chinese (Taiwan)", "zh_TW");
+			items.add("Spanish", "es");
 
 			if ((null == value) || (0 == value.length())) {
 				items.get(0).selected = true; // default to en_US
@@ -264,7 +264,7 @@ public class FortifyUpdate extends FortifyStep {
 
 	public static class Builder {
 		private String updateServerURL;
-		private String localeString;
+		private String locale;
 
 		public Builder() {
 		}
@@ -276,15 +276,15 @@ public class FortifyUpdate extends FortifyStep {
 			return this;
 		}
 
-		public Builder localeString(String localeString) {
+		public Builder locale(String localeString) {
 			if (StringUtils.isNotBlank(localeString)) {
-				this.localeString = localeString;
+				this.locale = localeString;
 			}
 			return this;
 		}
 
 		public FortifyUpdate build() {
-			return new FortifyUpdate(updateServerURL, localeString);
+			return new FortifyUpdate(updateServerURL, locale);
 		}
 
 	}

--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifyUpdate.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifyUpdate.java
@@ -248,8 +248,8 @@ public class FortifyUpdate extends FortifyStep {
 
 	private String getFortifyUpdateExecutable(Run<?, ?> build, FilePath workspace, Launcher launcher,
 			TaskListener listener) throws InterruptedException, IOException {
-		return getExecutable("fortifyupdate" + (launcher.isUnix() ? "" : ".cmd"), true, build, workspace, launcher,
-				listener);
+		return getExecutable("fortifyupdate" + (launcher.isUnix() ? "" : ".cmd"), true, build, workspace,
+				launcher, listener, null);
 	}
 
 	@Extension

--- a/src/main/java/com/fortify/plugin/jenkins/steps/types/JavaScanType.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/types/JavaScanType.java
@@ -86,8 +86,8 @@ public class JavaScanType extends ProjectScanType {
 
 		public ListBoxModel doFillJavaVersionItems(String value) {
 			ListBoxModel items = new ListBoxModel();
-			items.add("1.5", "1.5");
-			items.add("1.6", "1.6");
+			items.add("5", "5");
+			items.add("6", "6");
 			items.add("7", "7");
 			items.add("8", "8");
 			items.add("9", "9");
@@ -97,7 +97,7 @@ public class JavaScanType extends ProjectScanType {
 			items.add("13", "13");
 
 			if ((null == value) || (0 == value.length())) {
-				items.get(3).selected = true;
+				items.get(3).selected = true; // default to Java 8
 			}
 
 			return items;

--- a/src/main/java/com/fortify/plugin/jenkins/steps/types/JavaScanType.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/types/JavaScanType.java
@@ -84,16 +84,21 @@ public class JavaScanType extends ProjectScanType {
 			return Messages.JavaScanType_DisplayName();
 		}
 
-		public ListBoxModel doFillJavaVersionItems() {
+		public ListBoxModel doFillJavaVersionItems(String value) {
 			ListBoxModel items = new ListBoxModel();
 			items.add("1.5", "1.5");
 			items.add("1.6", "1.6");
-			items.add("1.7", "1.7");
-			items.add("1.8", "1.8");
-			items.add("1.9", "1.9");
+			items.add("7", "7");
+			items.add("8", "8");
+			items.add("9", "9");
 			items.add("10", "10");
 			items.add("11", "11");
 			items.add("12", "12");
+			items.add("13", "13");
+
+			if ((null == value) || (0 == value.length())) {
+				items.get(3).selected = true;
+			}
 
 			return items;
 		}

--- a/src/main/resources/com/fortify/plugin/jenkins/FortifyPlugin/config.jelly
+++ b/src/main/resources/com/fortify/plugin/jenkins/FortifyPlugin/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <!--
-    (c) Copyright 2019 Micro Focus or one of its affiliates.
+    (c) Copyright 2020 Micro Focus or one of its affiliates.
 
     Licensed under the MIT License (the "License");
     you may not use this file except in compliance with the License.
@@ -99,6 +99,9 @@
             <f:entry title="Update server URL" field="updateServerUrl" help="/plugin/fortify/help-updateServerUrl.html">
               <f:textbox/>
             </f:entry>
+            <f:entry title="Locale" field="localeString" help="/plugin/fortify/help-fortifyupdateLocale.html">
+              <f:select/>
+            </f:entry>
           </f:nested>
         </f:optionalBlock>
         </table>
@@ -191,6 +194,9 @@
           <f:nested>
             <f:entry title="Update server URL" field="updateServerUrl" help="/plugin/fortify/help-updateServerUrl.html">
               <f:textbox/>
+            </f:entry>
+            <f:entry title="Locale" field="localeString" help="/plugin/fortify/help-fortifyupdateLocale.html">
+              <f:select/>
             </f:entry>
           </f:nested>
         </f:optionalBlock>

--- a/src/main/resources/com/fortify/plugin/jenkins/FortifyPlugin/config.jelly
+++ b/src/main/resources/com/fortify/plugin/jenkins/FortifyPlugin/config.jelly
@@ -99,7 +99,7 @@
             <f:entry title="Update server URL" field="updateServerUrl" help="/plugin/fortify/help-updateServerUrl.html">
               <f:textbox/>
             </f:entry>
-            <f:entry title="Locale" field="localeString" help="/plugin/fortify/help-fortifyupdateLocale.html">
+            <f:entry title="Locale" field="locale" help="/plugin/fortify/help-fortifyupdateLocale.html">
               <f:select/>
             </f:entry>
           </f:nested>
@@ -195,7 +195,7 @@
             <f:entry title="Update server URL" field="updateServerUrl" help="/plugin/fortify/help-updateServerUrl.html">
               <f:textbox/>
             </f:entry>
-            <f:entry title="Locale" field="localeString" help="/plugin/fortify/help-fortifyupdateLocale.html">
+            <f:entry title="Locale" field="locale" help="/plugin/fortify/help-fortifyupdateLocale.html">
               <f:select/>
             </f:entry>
           </f:nested>

--- a/src/main/resources/com/fortify/plugin/jenkins/steps/FortifyUpdate/config.jelly
+++ b/src/main/resources/com/fortify/plugin/jenkins/steps/FortifyUpdate/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <!--
-    (c) Copyright 2019 Micro Focus or one of its affiliates.
+    (c) Copyright 2020 Micro Focus or one of its affiliates.
    
     Licensed under the MIT License (the "License");
     you may not use this file except in compliance with the License.
@@ -17,5 +17,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%Update server URL}" field="updateServerURL" help="/plugin/fortify/help-updateServerUrl.html">
         <f:textbox default="${descriptor.defaultURL}"/>
+    </f:entry>
+    <f:entry title="${%Locale}" field="localeString" help="/plugin/fortify/help-fortifyupdateLocale.html">
+    	<f:select/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/fortify/plugin/jenkins/steps/FortifyUpdate/config.jelly
+++ b/src/main/resources/com/fortify/plugin/jenkins/steps/FortifyUpdate/config.jelly
@@ -18,7 +18,7 @@
     <f:entry title="${%Update server URL}" field="updateServerURL" help="/plugin/fortify/help-updateServerUrl.html">
         <f:textbox default="${descriptor.defaultURL}"/>
     </f:entry>
-    <f:entry title="${%Locale}" field="localeString" help="/plugin/fortify/help-fortifyupdateLocale.html">
+    <f:entry title="${%Locale}" field="locale" help="/plugin/fortify/help-fortifyupdateLocale.html">
     	<f:select/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/fortify/plugin/jenkins/steps/remote/PhpProjectType/config.jelly
+++ b/src/main/resources/com/fortify/plugin/jenkins/steps/remote/PhpProjectType/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <!--
-    (c) Copyright 2019 Micro Focus or one of its affiliates.
+    (c) Copyright 2020 Micro Focus or one of its affiliates.
 
     Licensed under the MIT License (the "License");
     you may not use this file except in compliance with the License.
@@ -18,9 +18,4 @@
     <f:entry title="PHP version" help="/plugin/fortify/help-phpVersion.html">
         <f:textbox field="phpVersion"/>
     </f:entry>
-    <!--<f:advanced>
-        <f:entry title="Fortify SCA translation options" help="">
-            <f:textbox field="transArgs"/>
-        </f:entry>
-    </f:advanced>-->
 </j:jelly>

--- a/src/main/resources/com/fortify/plugin/jenkins/steps/remote/PythonProjectType/config.jelly
+++ b/src/main/resources/com/fortify/plugin/jenkins/steps/remote/PythonProjectType/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <!--
-    (c) Copyright 2019 Micro Focus or one of its affiliates.
+    (c) Copyright 2020 Micro Focus or one of its affiliates.
 
     Licensed under the MIT License (the "License");
     you may not use this file except in compliance with the License.
@@ -24,9 +24,4 @@
     <f:entry title="Python requirements file" help="/plugin/fortify/help-pythonRequirementsFile.html">
         <f:textbox field="pythonRequirementsFile"/>
     </f:entry>
-    <!--<f:advanced>
-        <f:entry title="Fortify SCA translation options" help="">
-            <f:textbox field="transArgs"/>
-        </f:entry>
-    </f:advanced>-->
 </j:jelly>

--- a/src/main/webapp/help-advancedTranslationOptions.html
+++ b/src/main/webapp/help-advancedTranslationOptions.html
@@ -1,5 +1,5 @@
 <!--
-    (c) Copyright 2019 Micro Focus or one of its affiliates.
+    (c) Copyright 2020 Micro Focus or one of its affiliates.
    
     Licensed under the MIT License (the "License");
     you may not use this file except in compliance with the License.
@@ -18,6 +18,6 @@
     Manually specify all SCA translate options, except for the build ID.
   </p>
   <p>
-	Enclose each option and value in double quotes, for example '"-source" "1.9" "-cp" "WEB-INF/lib/*.jar" "MyApp/src/**/*.java"'. 
+	Enclose each option and value in double quotes, for example '"-source" "9" "-cp" "WEB-INF/lib/*.jar" "MyApp/src/**/*.java"'.
   </p>
 </div>

--- a/src/main/webapp/help-controllerToken.html
+++ b/src/main/webapp/help-controllerToken.html
@@ -1,5 +1,5 @@
 <!--
-    (c) Copyright 2019 Micro Focus or one of its affiliates.
+    (c) Copyright 2020 Micro Focus or one of its affiliates.
 
     Licensed under the MIT License (the "License");
     you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
     limitations under the License.
  -->
 <div>
-    To upload remotely scanned FPR files to Fortify Software Security Center, you must have an authentication token of type CloudCtrlToken.
+    To upload remotely scanned FPR files to Fortify Software Security Center, you must have an authentication token of type ScanCentralCtrlToken.
     <p>
         You can obtain an authentication token from either the Administration view in Fortify Software Security Center or from the command-line
         with the fortifyclient utility.  See the Fortify Software Security Center User Guide for instructions on how to create an authentication token.

--- a/src/main/webapp/help-fortifyupdateLocale.html
+++ b/src/main/webapp/help-fortifyupdateLocale.html
@@ -14,6 +14,10 @@
     limitations under the License.
  -->
 <div>
-    Controller URL (for example, http://my.domain.com:8080/scancentral-ctrl)
-    <p>If the Software Security Center URL is populated, the plugin will use the Software Security Center configuration to determine the Controller location and this field will be disabled. This field is required if the SSC URL is not configured.</p>
+    <p>
+        Specify a locale for internationalized rulepacks. Default is en_US.
+    </p>
+    <p>
+        Available options: en_US, ja, ko, pt_BR, zh_CN, zh_TW
+    </p>
 </div>

--- a/src/main/webapp/help-fortifyupdateLocale.html
+++ b/src/main/webapp/help-fortifyupdateLocale.html
@@ -15,9 +15,9 @@
  -->
 <div>
     <p>
-        Specify a locale for internationalized rulepacks. Default is en_US.
+        Specify a locale for internationalized security content. Default is English.
     </p>
     <p>
-        Available options: en_US, ja, ko, pt_BR, zh_CN, zh_TW
+        Available options: English, Chinese Simplified, Chinese Traditional, Japanese, Korean, Portuguese (Brazil), Spanish
     </p>
 </div>

--- a/src/main/webapp/help-updateServerUrl.html
+++ b/src/main/webapp/help-updateServerUrl.html
@@ -1,5 +1,5 @@
 <!--
-    (c) Copyright 2019 Micro Focus or one of its affiliates.
+    (c) Copyright 2020 Micro Focus or one of its affiliates.
    
     Licensed under the MIT License (the "License");
     you may not use this file except in compliance with the License.
@@ -15,6 +15,6 @@
  -->
 <div>
   <p>
-  	Update server URL from where rulepacks should be downloaded.
+  	Update server URL from where rulepacks should be downloaded. Default: https://update.fortify.com
   </p>
 </div>


### PR DESCRIPTION
Updates executable name from cloudscan to scancentral to support the new version/naming. If the scancentral executable is not found, it will attempt to run the cloudscan executable (to support the older version of CloudScan CLI) (US270010). 
Also updates the executable not found message to make it more clear (D289127).