### PR TITLE
added setConnectTimeout for Large FPR upload

### DIFF
--- a/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
+++ b/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
@@ -50,7 +50,7 @@ public class ApiClientWrapper {
 		apiClient.setBasePath(uri + "/api/v1");
 		try {
 			apiClient.setApiKeyPrefix(AUTH_HEADER_TOKEN);
-                        apiClient.setConnectTimeout(integer.parseInt(System.getenv("FORTIFY_CONNECT_TIMEOUT"))*1000)
+                        apiClient.setConnectTimeout(Integer.parseInt(System.getenv("FORTIFY_CONNECT_TIMEOUT"))*1000)
 			apiClient.setApiKey(Base64.encodeBase64String(token.getBytes("UTF-8")));
 		} catch (UnsupportedEncodingException e) {
 			String msg = MessageFormat.format("[ERROR] Error encoding SSC auth token : {0}", token);

--- a/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
+++ b/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
@@ -50,7 +50,7 @@ public class ApiClientWrapper {
 		apiClient.setBasePath(uri + "/api/v1");
 		try {
 			apiClient.setApiKeyPrefix(AUTH_HEADER_TOKEN);
-                        apiClient.setConnectTimeout(Integer.parseInt(System.getenv("FORTIFY_CONNECT_TIMEOUT"))*1000)
+            apiClient.setConnectTimeout(Integer.parseInt(System.getenv("FORTIFY_CONNECT_TIMEOUT"))*1000)
 			apiClient.setApiKey(Base64.encodeBase64String(token.getBytes("UTF-8")));
 		} catch (UnsupportedEncodingException e) {
 			String msg = MessageFormat.format("[ERROR] Error encoding SSC auth token : {0}", token);

--- a/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
+++ b/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
@@ -50,7 +50,9 @@ public class ApiClientWrapper {
 		apiClient.setBasePath(uri + "/api/v1");
 		try {
 			apiClient.setApiKeyPrefix(AUTH_HEADER_TOKEN);
-            apiClient.setConnectTimeout(Integer.parseInt(System.getenv("FORTIFY_CONNECT_TIMEOUT"))*1000);
+			if(System.getenv("FORTIFY_CONNECT_TIMEOUT") != null){
+            	apiClient.setConnectTimeout(Integer.parseInt(System.getenv("FORTIFY_CONNECT_TIMEOUT"))*1000);
+			}
 			apiClient.setApiKey(Base64.encodeBase64String(token.getBytes("UTF-8")));
 		} catch (UnsupportedEncodingException e) {
 			String msg = MessageFormat.format("[ERROR] Error encoding SSC auth token : {0}", token);

--- a/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
+++ b/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
@@ -50,7 +50,7 @@ public class ApiClientWrapper {
 		apiClient.setBasePath(uri + "/api/v1");
 		try {
 			apiClient.setApiKeyPrefix(AUTH_HEADER_TOKEN);
-            apiClient.setConnectTimeout(Integer.parseInt(System.getenv("FORTIFY_CONNECT_TIMEOUT"))*1000)
+            apiClient.setConnectTimeout(Integer.parseInt(System.getenv("FORTIFY_CONNECT_TIMEOUT"))*1000);
 			apiClient.setApiKey(Base64.encodeBase64String(token.getBytes("UTF-8")));
 		} catch (UnsupportedEncodingException e) {
 			String msg = MessageFormat.format("[ERROR] Error encoding SSC auth token : {0}", token);


### PR DESCRIPTION
due to the jave socket timeout issue
13:17:36  com.fortify.ssc.restclient.ApiException: java.net.SocketTimeoutException: timeout
13:17:36  	at com.fortify.ssc.restclient.ApiClient.execute(ApiClient.java:846)
13:17:36  	at com.fortify.ssc.restclient.api.ArtifactOfProjectVersionControllerApi.uploadArtifactOfProjectVersionWithHttpInfo(ArtifactOfProjectVersionControllerApi.java:314)
13:17:36  	at com.fortify.ssc.restclient.api.ArtifactOfProjectVersionControllerApi.uploadArtifactOfProjectVersion(ArtifactOfProjectVersionControllerApi.java:298)
13:17:36  	at com.fortify.plugin.jenkins.fortifyclient.ApiClientWrapper.uploadFpr(ApiClientWrapper.java:498)
13:17:36  	at com.fortify.plugin.jenkins.fortifyclient.FortifyClient.uploadFPR(FortifyClient.java:155)