### PR TITLE
don't bail out when executable wasn't found initially

### DIFF
--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
@@ -85,7 +85,7 @@ public abstract class FortifyStep extends Step implements SimpleBuildStep {
 		}
 		String s = workspace.act(new FindExecutableRemoteService(filename, fortifyHome, path, workspace));
 		if (s == null) {
-			throw new FileNotFoundException("ERROR: executable not found: " + filename);
+			listener.getLogger().printf("Did not find executable: %s%n", filename);
 		} else {
 			listener.getLogger().printf("Found executable: %s%n", s);
 			return s;

--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
@@ -86,6 +86,7 @@ public abstract class FortifyStep extends Step implements SimpleBuildStep {
 		String s = workspace.act(new FindExecutableRemoteService(filename, fortifyHome, path, workspace));
 		if (s == null) {
 			listener.getLogger().printf("Did not find executable: %s%n", filename);
+			return filename;
 		} else {
 			listener.getLogger().printf("Found executable: %s%n", s);
 			return s;

--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
@@ -17,6 +17,8 @@ package com.fortify.plugin.jenkins.steps;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
@@ -72,6 +74,7 @@ public abstract class FortifyStep extends Step implements SimpleBuildStep {
 		EnvVars env = build.getEnvironment(listener);
 		String fortifyHome = null;
 		String path = null;
+		String hostname = getHostname();
 		// check env variables defined in Jenkins master
 		for (Map.Entry<String, String> entry : env.entrySet()) {
 			String key = entry.getKey();
@@ -85,10 +88,10 @@ public abstract class FortifyStep extends Step implements SimpleBuildStep {
 		}
 		String s = workspace.act(new FindExecutableRemoteService(filename, fortifyHome, path, workspace));
 		if (s == null) {
-			listener.getLogger().printf("Did not find executable: %s%n", filename);
+			listener.getLogger().printf("Did not find executable '%s' on hostname '%s'%n", filename, hostname);
 			return filename;
 		} else {
-			listener.getLogger().printf("Found executable: %s%n", s);
+			listener.getLogger().printf("Found executable '%s' on hostname '%s'%n", s, hostname);
 			return s;
 		}
 	}
@@ -156,4 +159,20 @@ public abstract class FortifyStep extends Step implements SimpleBuildStep {
 			args.add(s);
 		}
 	}
+
+    /**
+     * Determine the hostname that this is executing on
+     *
+     * @return hostname
+     */
+    protected String getHostname()
+    {
+        String hostname;
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            hostname = "(could not determine hostname)";
+        }
+        return hostname;
+    }
 }


### PR DESCRIPTION
Fix for #21 

I think the plugin was able to work via container back in 19.x because this executable finder failure did not choose to bail out with an exception.  Even though it didn't find anything, allowing the container execution to continue ended up showing that it _could_ still run everything successfully.  The introduction of this exception in 20.x now blocks that from continuing.

I've removed the exception, and just left it as logging the fact that the finder didn't find the executable.  If the plugin later fails to properly execute, then presumably another exception will occur at that point.