### PR TITLE
implemented upload-only option for the post-build action

### DIFF
--- a/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
+++ b/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
@@ -242,6 +242,10 @@ public class FortifyPlugin extends Recorder {
 		return getAnalysisRunType() && analysisRunType.value.equals("local");
 	}
 
+	public boolean isUploadOnly() {
+		return getAnalysisRunType() && analysisRunType.value.equals("uploadOnly");
+	}
+
 	public boolean isTranslationDebug() { return getAnalysisRunType() && analysisRunType.isTranslationDebug(); }
 	public boolean isTranslationVerbose() { return getAnalysisRunType() && analysisRunType.isTranslationVerbose(); }
 
@@ -533,7 +537,7 @@ public class FortifyPlugin extends Recorder {
 	}
 
 	public boolean getRemoteOptionalConfig() {
-		return !isLocal() && analysisRunType.getRemoteOptionalConfig() != null;
+		return !isLocal() && !isUploadOnly() && analysisRunType.getRemoteOptionalConfig() != null;
 	}
 
 	public String getSensorPoolUUID() {
@@ -630,6 +634,8 @@ public class FortifyPlugin extends Recorder {
 			runMixed(build, launcher, listener);
 		} else if (isLocal()) { // Local Translation
 			runLocal(build, launcher, listener);
+		} else if (isUploadOnly()) {
+			runUploadOnly(build, launcher, listener);
 		}
 
 		return true;
@@ -714,6 +720,21 @@ public class FortifyPlugin extends Recorder {
 			upload.perform(build, launcher, listener);
 		}
 
+	}
+
+	private void runUploadOnly(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+		PrintStream log = listener.getLogger();
+		log.println("Running upload-only step.");
+
+		if (getUploadSSC()) {
+			FortifyUpload upload = new FortifyUpload(false, getAppName(), getAppVersion());
+			upload.setFailureCriteria(getSearchCondition());
+			upload.setFilterSet(getFilterSet());
+			upload.setResultsFile(getScanFile());
+			upload.setPollingInterval(getPollingInterval());
+
+			upload.perform(build, launcher, listener);
+		}
 	}
 
 	private void performLocalTranslation(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {

--- a/src/main/resources/com/fortify/plugin/jenkins/FortifyPlugin/config.jelly
+++ b/src/main/resources/com/fortify/plugin/jenkins/FortifyPlugin/config.jelly
@@ -299,6 +299,54 @@
           </table>
         </f:block>
       </f:radioBlock>
+
+      <f:radioBlock title="No translation/scan - upload only" value="uploadOnly" name="analysisRunType"
+                    checked="${instance.isUploadOnly()}" help="/plugin/fortify/help-uploadOnly.html">
+
+        <f:entry field="scanFile" title="Results file" help="/plugin/fortify/help-fpr.html">
+          <f:textbox/>
+        </f:entry>
+
+        <f:block>
+          <table style="width:100%;">
+            <f:optionalBlock field="uploadSSC" title="Upload Fortify SCA scan results to Fortify Software Security Center">
+              <f:entry title="Application name" help="/plugin/fortify/help-sscProjName.html">
+                <script type="text/javascript" src="${rootURL}/plugin/fortify/refresh-projects.js"/>
+                <div style="float:left;width:80%;">
+                  <f:editableComboBox id="projectName" field="appName" clazz="setting-input project-name" items="${descriptor.appNameItems}" />
+                </div>
+                <div style="float:left">
+                  <input value="▼" type="button" id="refreshPrjButton" onclick="refreshProjectNames('${rootURL}/descriptor/${descriptor.clazz.name}/refreshProjects', this)" />
+                </div>
+                <div style="display:none;" id="refreshSpinner" >
+                  <img src="${imagesURL}/spinner.gif" /> ${progress}
+                </div>
+              </f:entry>
+              <f:entry title="Application version" help="/plugin/fortify/help-sscProjVersion.html">
+                <div style="float:left;width:50%;">
+                  <f:editableComboBox id="projectVersion" field="appVersion" clazz="setting-input project-version" items="${descriptor.appVersionItems(appName)}" />
+                </div>
+                <div style="float:left">
+                  <input value="▼" type="button" id="refreshPrjVerButton" onclick="refreshProjectVersions('${rootURL}/descriptor/${descriptor.clazz.name}/refreshVersions', this)" />
+                </div>
+              </f:entry>
+              <f:entry field="filterSet" title="Filter set" help="/plugin/fortify/help-filterSet.html">
+                <f:textbox/>
+              </f:entry>
+              <f:entry field="searchCondition" title="Build failure criteria" help="/plugin/fortify/help-search.html">
+                <f:textbox/>
+              </f:entry>
+              <f:advanced title="Advanced settings">
+                <f:entry field="pollingInterval" title="Polling interval" help="/plugin/fortify/help-pollingInterval.html">
+                  <f:textbox/>
+                </f:entry>
+              </f:advanced>
+            </f:optionalBlock>
+          </table>
+        </f:block>
+      </f:radioBlock>
+
+
     </table>
   </f:block>
 </j:jelly>

--- a/src/main/webapp/help-uploadOnly.html
+++ b/src/main/webapp/help-uploadOnly.html
@@ -1,0 +1,21 @@
+<!--
+    (c) Copyright 2019 Micro Focus or one of its affiliates.
+
+    Licensed under the MIT License (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://opensource.org/licenses/MIT
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ -->
+<div>
+    <p>
+        Do not run a Fortify SCA translation and/or scan. Only use the plugin for uploading. This is useful if you
+        have decided to configure the scanning process outside of the plugin.
+    </p>
+</div>


### PR DESCRIPTION
In earlier versions of this plugin, it was possible to use the plugin for uploading to SSC only, while obtaining the FPR through your own scripting outside of the plugin. In the 20.1 plugin, this is no longer possible: users have to configure Remote Translation/Remote Scan, Local Translation/Remote Scan or Local Translation/Local Scan, but they can't choose _no scan_.

While uploading to SSC is possible through fortifyclient (without the plugin) there is an added value of doing it through the plugin, because of the display of results in Jenkins and the possibility to break the build. Some Fortify users are missing this functionality in the current plugin.

This PR modifies the plugin to add a 4th option to the 3 existing ones, which is "upload only", doing exactly what the name suggests.