### PR TITLE
Jenkins latest version upgrade

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -7,7 +7,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="target/generated-sources/localizer"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.53</version>
+        <version>4.73</version>
         <relativePath />
     </parent>
 
@@ -32,7 +32,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jenkins.version>2.361.4</jenkins.version>
         <bom>2.361.x</bom>
-        <bom.version>1706.vc166d5f429f8</bom.version>
+        <bom.version>2102.v854b_fec19c92</bom.version>
         <disabledTestInjection>true</disabledTestInjection>
         <hpi.compatibleSinceVersion>20.2.34</hpi.compatibleSinceVersion>
     </properties>
@@ -110,6 +110,29 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- this overrides the version provided with ssc-restapi-client -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Using lang3.tuple -->
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Email address validation -->
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jakarta-mail-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- for Jenkins Pipelines -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -117,18 +140,11 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- for Configuration as a Code -->
-        <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
-            <scope>compile</scope>
-        </dependency>
-
         <!-- for Gradle Global Tool Configuration support -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>gradle</artifactId>
-            <version>1.40</version>
+            <version>2.9</version>
         </dependency>
 
         <!-- for Credentials support -->
@@ -150,25 +166,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <!-- this overrides the version provided with ssc-restapi-client -->
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>4.12.0</version>
-            <type>jar</type>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>jakarta-mail-api</artifactId>
-            <version>2.0.1-3</version>
-            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
+++ b/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
@@ -30,8 +30,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.CheckForNull;
-
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
@@ -78,6 +76,7 @@ import com.fortify.plugin.jenkins.steps.types.OtherScanType;
 import com.fortify.plugin.jenkins.steps.types.ProjectScanType;
 import com.fortify.ssc.restclient.ApiException;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.AbortException;
 import hudson.BulkChange;
 import hudson.Extension;
@@ -88,6 +87,8 @@ import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.BuildListener;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.security.ACL;
 import hudson.tasks.BuildStepDescriptor;
@@ -98,6 +99,7 @@ import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
@@ -126,7 +128,7 @@ import okhttp3.ResponseBody;
  * </ul>
  *
  */
-public class FortifyPlugin extends Recorder {
+public class FortifyPlugin extends Recorder implements Describable<Publisher> {
 	private static String pluginVersion;
 
 	public static String getPluginVersion() {

--- a/src/main/java/com/fortify/plugin/jenkins/credentials/FortifyApiToken.java
+++ b/src/main/java/com/fortify/plugin/jenkins/credentials/FortifyApiToken.java
@@ -3,24 +3,24 @@ package com.fortify.plugin.jenkins.credentials;
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.NameWith;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
 import hudson.util.Secret;
 
 import java.io.IOException;
 
-import javax.annotation.Nonnull;
-
 @NameWith(value = FortifyApiToken.NameProvider.class, priority = 1)
 public interface FortifyApiToken extends StandardCredentials {
 
-    @Nonnull
+    @NonNull
     Secret getToken() throws IOException, InterruptedException;
 
     class NameProvider extends CredentialsNameProvider<FortifyApiToken> {
 
-        @Nonnull
+        @NonNull
         @Override
-        public String getName(@Nonnull final FortifyApiToken credentials) {
+        public String getName(@NonNull final FortifyApiToken credentials) {
             final String description = Util.fixEmptyAndTrim(credentials.getDescription());
             return credentials.getId() + "/*fortify*" + (description != null ? " (" + description + ")" : "");
         }

--- a/src/main/java/com/fortify/plugin/jenkins/credentials/StandardFortifyApiToken.java
+++ b/src/main/java/com/fortify/plugin/jenkins/credentials/StandardFortifyApiToken.java
@@ -1,7 +1,25 @@
+/*******************************************************************************
+ * Copyright 2020-2023 Open Text.
+ *
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
 package com.fortify.plugin.jenkins.credentials;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
@@ -13,9 +31,6 @@ import org.jenkins.ui.icon.IconType;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-
 /**
  * Default implementation of {@link FortifyApiToken} for use by Jenkins {@link com.cloudbees.plugins.credentials.CredentialsProvider}
  * instances that store {@link Secret} locally.
@@ -24,16 +39,16 @@ public class StandardFortifyApiToken extends BaseStandardCredentials implements 
 
 	private static final long serialVersionUID = -7103736612075250489L;
 
-    @Nonnull
+    @NonNull
     private final Secret token;
 
     @DataBoundConstructor
-    public StandardFortifyApiToken(@CheckForNull CredentialsScope scope, @CheckForNull String id, @Nonnull String token, @CheckForNull String description) {
+    public StandardFortifyApiToken(@CheckForNull CredentialsScope scope, @CheckForNull String id, @NonNull String token, @CheckForNull String description) {
         super(scope, id, description);
         this.token = Secret.fromString(token);
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Secret getToken() {
         return this.token;
@@ -42,7 +57,7 @@ public class StandardFortifyApiToken extends BaseStandardCredentials implements 
     @Extension
     public static class DefaultFortifyApiTokenDescriptor extends BaseStandardCredentials.BaseStandardCredentialsDescriptor {
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Fortify Connection Token";

--- a/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
+++ b/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2019 Micro Focus or one of its affiliates.
+ * Copyright 2019-2023 Open Text.
  *
  * Licensed under the MIT License (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import java.io.UnsupportedEncodingException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.annotation.Nonnull;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
@@ -69,6 +67,8 @@ import com.fortify.ssc.restclient.model.Project;
 import com.fortify.ssc.restclient.model.ProjectVersion;
 import com.fortify.ssc.restclient.model.ProjectVersionIssue;
 import com.fortify.ssc.restclient.model.ProjectVersionIssueGroup;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class ApiClientWrapper {
 	private static final String AUTH_HEADER_TOKEN = "FortifyToken";
@@ -534,7 +534,7 @@ public class ApiClientWrapper {
 	 * @return id of the uploaded artifact
 	 * @throws ApiException
 	 */
-	public Long uploadFpr(@Nonnull File fpr, @Nonnull Long appVersionId) throws ApiException {
+	public Long uploadFpr(@NonNull File fpr, @NonNull Long appVersionId) throws ApiException {
 		ArtifactOfProjectVersionControllerApi artifactOfProjectVersionControllerApi = new ArtifactOfProjectVersionControllerApi(
 				apiClient);
 		ApiResultArtifact result = artifactOfProjectVersionControllerApi.uploadArtifactOfProjectVersion(appVersionId,
@@ -542,7 +542,7 @@ public class ApiClientWrapper {
 		return result.getData().getId();
 	}
 
-	public Artifact getArtifactInfo(@Nonnull Long artifactId) throws ApiException {
+	public Artifact getArtifactInfo(@NonNull Long artifactId) throws ApiException {
 		ArtifactControllerApi artifactControllerApi = new ArtifactControllerApi(apiClient);
 		return artifactControllerApi.readArtifact(artifactId, null, null).getData();
 	}

--- a/src/test/java/com/fortify/plugin/jenkins/FortifyJCasCCompatibilityTest.java
+++ b/src/test/java/com/fortify/plugin/jenkins/FortifyJCasCCompatibilityTest.java
@@ -4,14 +4,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 import hudson.ProxyConfiguration;
 import hudson.util.Secret;
-import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
 import jenkins.model.Jenkins;
 
-public class FortifyJCasCCompatibilityTest extends RoundTripAbstractTest {
+public class FortifyJCasCCompatibilityTest {
+
+	@Rule
+	public final JenkinsConfiguredWithCodeRule jenkinsConfiguredWithRule = new JenkinsConfiguredWithCodeRule();
 
 	/*
 	 * Resource: /com.fortify.plugin.jenkins/src/test/resources/com/fortify/plugin/jenkins/configuration-as-code.yaml
@@ -31,9 +36,10 @@ public class FortifyJCasCCompatibilityTest extends RoundTripAbstractTest {
 	 *     ctrlUrl: "https://qa-cs-r-ctrl.prgqa.hpecorp.net:8443/scancentral-ctrl/"
 	 *     ctrlToken: "iamclient!"
 	 */
-	@Override
-	protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
-		FortifyPlugin.DescriptorImpl descriptor = FortifyPlugin.DESCRIPTOR;
+	@Test
+	@ConfiguredWithCode("com/fortify/plugin/jenkins/configuration-as-code.yml")
+	public void assertConfiguredAsExpected() {
+		final FortifyPlugin.DescriptorImpl descriptor = (FortifyPlugin.DescriptorImpl) jenkinsConfiguredWithRule.jenkins.getDescriptorOrDie(FortifyPlugin.class);
 		assertTrue("Fortify plugin can not be found", descriptor != null);
 		assertEquals(String.format("Wrong SSC URL. Expected %s but received %s", "https://qa-plg-ssc3.prgqa.hpecorp.net:8443/ssc", descriptor.getUrl()),
 				"https://qa-plg-ssc3.prgqa.hpecorp.net:8443/ssc", descriptor.getUrl());
@@ -59,10 +65,4 @@ public class FortifyJCasCCompatibilityTest extends RoundTripAbstractTest {
 		assertEquals(String.format("Local scan setting is incorrect. Expected %s but received %s", true, descriptor.isDisableLocalScans()),
 				true, descriptor.isDisableLocalScans());
 	}
-
-	@Override
-	protected String stringInLogExpected() {
-		return "";
-	}
-
 }


### PR DESCRIPTION
Attempting to get the code to the most recent state in order to overcome build failure.
Struggling with getting rid of the "Unable to inject class hudson.model.UserIdMapper".

1. Updated the parent pom
2. Updated the bom to the required jenkins base version
3. Rewrote the FortifyJCasCCompatibilityTest test
4. Replaced javax.annotation-s with the findbugs ones

The tests are still failing: 
```
[ERROR] com.fortify.plugin.jenkins.FortifyJCasCCompatibilityTest.assertConfiguredAsExpected -- Time elapsed: 12.30 s <<< ERROR!
org.jvnet.hudson.reactor.ReactorException: java.lang.IllegalArgumentException: Unable to inject class hudson.model.UserIdMapper
        at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:291)
        at jenkins.InitReactorRunner.run(InitReactorRunner.java:49)
        at jenkins.model.Jenkins.executeReactor(Jenkins.java:1196)
        at jenkins.model.Jenkins.<init>(Jenkins.java:986)
        at hudson.model.Hudson.<init>(Hudson.java:86)
        at org.jvnet.hudson.test.JenkinsRule.newHudson(JenkinsRule.java:697)
        at org.jvnet.hudson.test.JenkinsRule.before(JenkinsRule.java:406)
        at io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule.before(JenkinsConfiguredWithCodeRule.java:23)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:601)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.IllegalArgumentException: Unable to inject class hudson.model.UserIdMapper
        at hudson.init.TaskMethodFinder.lookUp(TaskMethodFinder.java:130)
        at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)
        at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:185)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1161)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:222)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:121)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:70)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        ... 1 more

``` 