### PR TITLE
Fix Javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,12 +190,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <failOnError>false</failOnError>
-                    </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
+++ b/src/main/java/com/fortify/plugin/jenkins/FortifyPlugin.java
@@ -1082,7 +1082,7 @@ public class FortifyPlugin extends Recorder {
 		}
 
 		// backwards compatibility
-		/** @deprecated use {@link #setSscTokenCredentialsId()} */
+		/** @deprecated use {@link #setSscTokenCredentialsId(String)} */
 		@DataBoundSetter
 		public void setToken(String token) {
 			String defaultMigratedTokenId = "fortify_api_token";
@@ -1196,7 +1196,7 @@ public class FortifyPlugin extends Recorder {
 			return ctrlUserToken == null ? "" : ctrlUserToken.getPlainText();
 		}
 
-		/** @deprecated use {@link #setCtrlTokenCredentialsId()} */
+		/** @deprecated use {@link #setCtrlTokenCredentialsId(String)} */
 		@DataBoundSetter
 		public void setCtrlToken(String ctrlToken) { 
 			String defaultMigratedCtrlTokenId = "fortify_ctrl_token";
@@ -1957,11 +1957,11 @@ public class FortifyPlugin extends Recorder {
 		}
 
 		/**
-		 * Get Issue template list from SSC via WS <br/>
+		 * Get Issue template list from SSC via WS
+		 * <p>
 		 * Basically only for global.jelly pull down menu
 		 *
 		 * @return A list of Issue template and ID
-		 * @throws ApiException
 		 */
 		@POST
 		public ComboBoxModel doFillProjectTemplateItems(@AncestorInPath Item item) {

--- a/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
+++ b/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ApiClientWrapper.java
@@ -109,9 +109,6 @@ public class ApiClientWrapper {
 	/**
 	 * Returns list of Applications in SSC. Returns empty list of no Applications
 	 * are found.
-	 *
-	 * @return List<Project>
-	 * @throws ApiException
 	 */
 	public List<Project> getApplications(String query, int limit) throws ApiException {
 		List<Project> appList = new ArrayList<Project>();
@@ -128,9 +125,6 @@ public class ApiClientWrapper {
 	/**
 	 * Returns list of Application Versions in SSC. Returns empty list of no
 	 * Applications Versions are found.
-	 *
-	 * @return List<ProjectVersion>
-	 * @throws ApiException
 	 */
 	public List<ProjectVersion> getAllApplicationVersions(String query, int limit) throws ApiException {
 		List<ProjectVersion> appVersionList = new ArrayList<ProjectVersion>();
@@ -147,9 +141,6 @@ public class ApiClientWrapper {
 
 	/**
 	 * Returns list of Application Versions for a particular Application in SSC.
-	 *
-	 * @return List<ProjectVersion>
-	 * @throws ApiException
 	 */
 	public List<ProjectVersion> getApplicationVersionsFor(long applicationId, String query, int limit) throws ApiException {
 		List<ProjectVersion> appVersionList = new ArrayList<ProjectVersion>();
@@ -167,9 +158,6 @@ public class ApiClientWrapper {
 	/**
 	 * Returns list of Attribute Definitions in SSC. Returns empty list if no
 	 * Attribute Definitions are found.
-	 *
-	 * @return List<AttributeDefinition>
-	 * @throws ApiException
 	 */
 	public List<AttributeDefinition> getAttributeDefinitions() throws ApiException {
 		List<AttributeDefinition> attrDefinitionList = new ArrayList<AttributeDefinition>();
@@ -185,9 +173,6 @@ public class ApiClientWrapper {
 	/**
 	 * Returns list of Issue Templates in SSC. Returns empty list if no Issue
 	 * Templates are found.
-	 *
-	 * @return List<IssueTemplate>
-	 * @throws ApiException
 	 */
 	public List<IssueTemplate> getIssueTemplates() throws ApiException {
 		List<IssueTemplate> issueTemplateList = new ArrayList<IssueTemplate>();
@@ -202,8 +187,6 @@ public class ApiClientWrapper {
 
 	/**
 	 * Returns a list of CloudScan Pools in SSC. Returns an empty list if no pools are found.
-	 * @return List<CloudPool>
-	 * @throws ApiException
 	 */
 	public List<CloudPool> getCloudScanPools() throws ApiException {
 		List<CloudPool> cloudPoolList = new ArrayList<>();
@@ -380,9 +363,6 @@ public class ApiClientWrapper {
 	/**
 	 * Get the default Issue Template if defined, otherwise return first one in
 	 * list.
-	 *
-	 * @return IssueTemplate
-	 * @throws ApiException
 	 */
 	private IssueTemplate getDefaultIssueTemplate() throws ApiException {
 		IssueTemplate issueTemplate = null;

--- a/src/main/java/com/fortify/plugin/jenkins/fortifyclient/FortifyClient.java
+++ b/src/main/java/com/fortify/plugin/jenkins/fortifyclient/FortifyClient.java
@@ -77,9 +77,6 @@ public class FortifyClient {
 
 	/**
 	 * Retrieve the application version list from SSC
-	 *
-	 * @return Map<String, Long>
-	 * @throws ApiException
 	 */
 	public Map<String, Map<String, Long>> getAllVersionListEx(String query, Integer limit) throws ApiException {
 		Map<String, Map<String, Long>> appVersionList = new LinkedHashMap<String, Map<String, Long>>();
@@ -101,10 +98,6 @@ public class FortifyClient {
 
 	/**
 	 * Retrieve the application version list for the @appId from SSC
-	 * @param appId
-	 *
-	 * @return Map<String, Map<String, Long>>
-	 * @throws ApiException
 	 */
 	public Map<String, Long> getVersionListEx(Long appId, String query, int limit) throws ApiException {
 		Map<String, Long> versions = new LinkedHashMap<String, Long>();
@@ -119,9 +112,6 @@ public class FortifyClient {
 
 	/**
 	 * Retrieve the application list from SSC
-	 *
-	 * @return Map<String, Long>
-	 * @throws ApiException
 	 */
 	public Map<String, Long> getProjectList(String query, int limit) throws ApiException {
 		Map<String, Long> projectList = new LinkedHashMap<String, Long>();
@@ -213,8 +203,6 @@ public class FortifyClient {
 	 *
 	 * @param projectVersionId
 	 *            id of the application version to audit
-	 * @return Map<String, IssueBean>
-	 * @throws ApiException
 	 */
 	public Map<String, IssueBean> getIssuesByFolderId(Long projectVersionId, String folderId, int startPage,
 													  int pageSize, String filterSet, String groupingName, String sortOrder, Boolean ShowOnlyNewIssues,
@@ -283,10 +271,9 @@ public class FortifyClient {
 	 *
 	 * @param projectVersionId
 	 *            id of the application version to audit
-	 * @return Map<String, List<String>> map of attribute id -> list of attributes:
+	 * @return map of attribute id -&gt; list of attributes:
 	 *         package, className, function, sourceFilePath, filePath, lineNumber,
 	 *         url, groupName, assignedUser, category, type, confidence, severity
-	 * @throws ApiException
 	 */
 	public Map<String, List<String>> getGroupingValues(Long projectVersionId, String folderId, String filterSet,
 													   String searchCondition, String groupingName, PrintWriter log) throws ApiException {
@@ -299,9 +286,8 @@ public class FortifyClient {
 	 *
 	 * @param versionId
 	 *            id of the application version to audit
-	 * @return Map<String, List<String>> map of folder id -> list of attributes:
+	 * @return map of folder id -&gt; list of attributes:
 	 *         name, description, color, totalIssueCount
-	 * @throws ApiException
 	 */
 	public Map<String, List<String>> getFolderIdToAttributesList(Long versionId, String filterSetGuid, PrintWriter log)
 			throws ApiException {
@@ -434,10 +420,6 @@ public class FortifyClient {
 
 	/**
 	 * Retrieve the list of FilterSets for the @verId from SSC
-	 * @param verId
-	 *
-	 * @return Map<String, Map<String, Long>>
-	 * @throws ApiException
 	 */
 	public Map<String, String> getFilterSetListEx(Long verId) throws ApiException {
 		Map<String, String> result = new LinkedHashMap<String, String>();

--- a/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ProjectCreationService.java
+++ b/src/main/java/com/fortify/plugin/jenkins/fortifyclient/ProjectCreationService.java
@@ -199,7 +199,7 @@ public class ProjectCreationService {
 	}
 
 	/**
-	 * Get the Application Version Id for given appName & appVersionName, if it
+	 * Get the Application Version Id for given appName &amp; appVersionName, if it
 	 * exists
 	 *
 	 * @return Long appVersionId

--- a/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
+++ b/src/main/java/com/fortify/plugin/jenkins/steps/FortifyStep.java
@@ -58,15 +58,7 @@ public abstract class FortifyStep extends Step implements SimpleBuildStep {
 	 * Search for the executable filename in executable home directory or on PATH environment
 	 * variable or in workspace
 	 *
-	 * @param filename
-	 * @param build
-	 * @param workspace
-	 * @param listener
-	 * @param targetEnvVarName
-	 * @param vars 
 	 * @return found executable
-	 * @throws InterruptedException
-	 * @throws IOException
 	 */
 	protected String getExecutable(String filename, Run<?, ?> build, FilePath workspace,
 			TaskListener listener, String targetEnvVarName, EnvVars env) throws InterruptedException, IOException {


### PR DESCRIPTION
Fix Javadoc warnings and re-enable Javadoc generation.

### Testing done

Ran `mvn clean verify -DskipTests -Pjenkins-release` on both Java 11 and 17.